### PR TITLE
Support shorthand version in Node.js

### DIFF
--- a/nodejs/nodejs.lua
+++ b/nodejs/nodejs.lua
@@ -131,6 +131,7 @@ function PLUGIN:Available(ctx)
         })
     end
     table.sort(result, compare_versions)
+    available_result = result
     return result
 end
 

--- a/nodejs/npmmirror.lua
+++ b/nodejs/npmmirror.lua
@@ -131,6 +131,7 @@ function PLUGIN:Available(ctx)
         })
     end
     table.sort(result, compare_versions)
+    available_result = result
     return result
 end
 

--- a/nodejs/npmmirror.lua
+++ b/nodejs/npmmirror.lua
@@ -21,22 +21,18 @@ PLUGIN = {
     updateUrl = "https://raw.githubusercontent.com/version-fox/version-fox-plugins/main/nodejs/npmmirror.lua",
 }
 
-local is_debug = os.getenv("DEBUG")
-
 function PLUGIN:PreInstall(ctx)
     local version = ctx.version
 
     if version == "latest" then
-        local result = self:Available({})
-        version = result['list'][1].version
+        local lists = self:Available({})
+        version = lists[1].version
     end
 
     if not is_semver_simple(version) then
-        local result = self:Available({})
-        version = result['versions_shorthand'][version]
-        if is_debug then
-            print_table(result, 0)
-        end
+        local lists = self:Available({})
+        local shorthands = calculate_shorthand(lists)
+        version = shorthands[version]
     end
 
     if (version == nil) then
@@ -120,14 +116,11 @@ function PLUGIN:Available(ctx)
         return {}
     end
     local body = json.decode(resp.body)
-    local list = {}
-    local versions_shorthand = {}
+    local result = {}
 
     for _, v in ipairs(body) do
-        local version = string.gsub(v.version, "^v", "")
-        local major, minor = extract_semver(version)
-        table.insert(list, {
-            version = version,
+        table.insert(result, {
+            version = string.gsub(v.version, "^v", ""),
             note = v.lts and "LTS" or "",
             addition = {
                 {
@@ -136,34 +129,8 @@ function PLUGIN:Available(ctx)
                 }
             }
         })
-        if major then
-            if not versions_shorthand[major] then
-                versions_shorthand[major] = version
-            else
-                if compare_versions({version = version}, {version = versions_shorthand[major]}) then
-                    versions_shorthand[major] = version
-                end
-            end
-
-            if minor then
-                local major_minor = major .. "." .. minor
-                if not versions_shorthand[major_minor] then
-                    versions_shorthand[major_minor] = version
-                else
-                    if compare_versions({version = version}, {version = versions_shorthand[major_minor]}) then
-                        versions_shorthand[major_minor] = version
-                    end
-                end
-            end
-        end
     end
-
-    table.sort(list, compare_versions)
-
-    local result = {}
-    result['list'] = list
-    result['versions_shorthand'] = versions_shorthand
-    available_result = result
+    table.sort(result, compare_versions)
     return result
 end
 
@@ -207,17 +174,33 @@ function extract_semver(semver)
     return major, minor
 end
 
-function print_table(t, indent)
-    indent = indent or 0
-    local strIndent = string.rep("  ", indent)
-    for key, value in pairs(t) do
-        local keyStr = tostring(key)
-        local valueStr = tostring(value)
-        if type(value) == "table" then
-            print(strIndent .. "[" .. keyStr .. "] =>")
-            print_table(value, indent + 1)
-        else
-            print(strIndent .. "[" .. keyStr .. "] => " .. valueStr)
+function calculate_shorthand(list)
+    local versions_shorthand = {}
+    for _, v in ipairs(list) do
+        local version = v.version
+        local major, minor = extract_semver(version)
+
+        if major then
+            if not versions_shorthand[major] then
+                versions_shorthand[major] = version
+            else
+                if compare_versions({version = version}, {version = versions_shorthand[major]}) then
+                    versions_shorthand[major] = version
+                end
+            end
+
+            if minor then
+                local major_minor = major .. "." .. minor
+                if not versions_shorthand[major_minor] then
+                    versions_shorthand[major_minor] = version
+                else
+                    if compare_versions({version = version}, {version = versions_shorthand[major_minor]}) then
+                        versions_shorthand[major_minor] = version
+                    end
+                end
+            end
         end
     end
+
+    return versions_shorthand
 end

--- a/nodejs/npmmirror.lua
+++ b/nodejs/npmmirror.lua
@@ -16,18 +16,33 @@ VersionSourceUrl = "https://cdn.npmmirror.com/binaries/node/index.json"
 PLUGIN = {
     name = "nodejs",
     author = "yimiaoxiehou",
-    version = "0.0.1",
+    version = "0.0.2",
     description = "install Node.js use https://cdn.npmmirror.com",
     updateUrl = "https://raw.githubusercontent.com/version-fox/version-fox-plugins/main/nodejs/npmmirror.lua",
 }
+
+local is_debug = os.getenv("DEBUG")
 
 function PLUGIN:PreInstall(ctx)
     local version = ctx.version
 
     if version == "latest" then
-        local lists = self:Available({})
-        version = lists[1].version
+        local result = self:Available({})
+        version = result['list'][1].version
     end
+
+    if not is_semver_simple(version) then
+        local result = self:Available({})
+        version = result['versions_shorthand'][version]
+        if is_debug then
+            print_table(result, 0)
+        end
+    end
+
+    if (version == nil) then
+        error("version not found for provided version " .. version)
+    end
+
     local arch_type = ARCH_TYPE
     local ext = ".tar.gz"
     local osType = OS_TYPE
@@ -91,7 +106,13 @@ function get_checksum(file_content, file_name)
     return nil
 end
 
+available_result = nil
+
 function PLUGIN:Available(ctx)
+    if available_result then
+        return available_result
+    end
+
     local resp, err = http.get({
         url = VersionSourceUrl
     })
@@ -99,10 +120,14 @@ function PLUGIN:Available(ctx)
         return {}
     end
     local body = json.decode(resp.body)
-    local result = {}
+    local list = {}
+    local versions_shorthand = {}
+
     for _, v in ipairs(body) do
-        table.insert(result, {
-            version = string.gsub(v.version, "^v", ""),
+        local version = string.gsub(v.version, "^v", "")
+        local major, minor = extract_semver(version)
+        table.insert(list, {
+            version = version,
             note = v.lts and "LTS" or "",
             addition = {
                 {
@@ -111,13 +136,44 @@ function PLUGIN:Available(ctx)
                 }
             }
         })
+        if major then
+            if not versions_shorthand[major] then
+                versions_shorthand[major] = version
+            else
+                if compare_versions({version = version}, {version = versions_shorthand[major]}) then
+                    versions_shorthand[major] = version
+                end
+            end
+
+            if minor then
+                local major_minor = major .. "." .. minor
+                if not versions_shorthand[major_minor] then
+                    versions_shorthand[major_minor] = version
+                else
+                    if compare_versions({version = version}, {version = versions_shorthand[major_minor]}) then
+                        versions_shorthand[major_minor] = version
+                    end
+                end
+            end
+        end
     end
-    table.sort(result, compare_versions)
+
+    table.sort(list, compare_versions)
+
+    local result = {}
+    result['list'] = list
+    result['versions_shorthand'] = versions_shorthand
+    available_result = result
     return result
 end
 
 --- Expansion point
 function PLUGIN:PostInstall(ctx)
+    local rootPath = ctx.rootPath
+    local sdkInfo = ctx.sdkInfo['nodejs']
+    local path = sdkInfo.path
+    local version = sdkInfo.version
+    local name = sdkInfo.name
 end
 
 function PLUGIN:EnvKeys(ctx)
@@ -136,5 +192,32 @@ function PLUGIN:EnvKeys(ctx)
                 value = version_path .. "/bin"
             },
         }
+    end
+end
+
+function is_semver_simple(str)
+    -- match pattern: three digits, separated by dot
+    local pattern = "^%d+%.%d+%.%d+$"
+    return str:match(pattern) ~= nil
+end
+
+function extract_semver(semver)
+    local pattern = "^(%d+)%.(%d+)%.[%d.]+$"
+    local major, minor = semver:match(pattern)
+    return major, minor
+end
+
+function print_table(t, indent)
+    indent = indent or 0
+    local strIndent = string.rep("  ", indent)
+    for key, value in pairs(t) do
+        local keyStr = tostring(key)
+        local valueStr = tostring(value)
+        if type(value) == "table" then
+            print(strIndent .. "[" .. keyStr .. "] =>")
+            print_table(value, indent + 1)
+        else
+            print(strIndent .. "[" .. keyStr .. "] => " .. valueStr)
+        end
     end
 end


### PR DESCRIPTION
Support install node by `nodejs@20` expression, also support `nodejs@x.x`

![CleanShot 2024-02-21 at 12 13 37@2x](https://github.com/version-fox/version-fox-plugins/assets/13938334/9788bff1-ef31-4c10-91dd-11b002695437)

![CleanShot 2024-02-21 at 12 13 55@2x](https://github.com/version-fox/version-fox-plugins/assets/13938334/73ac528f-cd42-42c6-8ae5-f2d5238b1107)

Fix #14 